### PR TITLE
Markdownlint + WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,19 @@
 We recommend using Ruby Version Manager (RVM) to [Install Ruby](https://rvm.io/rvm/install)
 
 - Clone and set up wiki:
-```
+
+```sh
+
 git clone https://github.com/RPCSX/wiki
 cd wiki
+
 ```
+
 Note: Do not run Bundler as root. Installing your bundle as root will break this application for all
 non-root users on your machine.
-```
+
+```sh
+
 gem install bundler
 bundle install
 ```
@@ -23,9 +29,11 @@ bundle install
 - Run Jekyll Server:
 
 Note: Hot reloading is unsupported, refresh the page to see changes.
-```
+
+```sh
 bundle exec jekyll serve
 ```
+
 ### Before Pushing Changes
 
 Run `rubocop` on your local files.

--- a/faq.md
+++ b/faq.md
@@ -6,19 +6,19 @@ permalink: /faq/
 description: Frequently Asked Questions about RPCSX.
 ---
 
-## What is RPCSX?
+## Q: What is RPCSX?
 
 **A:** RPCSX is an experimental emulator for PS4 games (and later, PS5 games). Development is ongoing.
 
-## Can I play Bloodborne?
+## Q: Can I play Bloodborne?
 
 **A:** Not yet.
 
-## Can I run RPCSX on Windows?
+## Q: Can I run RPCSX on Windows?
 
 **A:** Yes, But only through WSL at this time. [learn more](/wiki/installation/#method-2-wsl)
 
-## What is the current state of the project?
+## Q: What is the current state of the project?
 
 **A:** The emulator can run test samples and play in-game on [We Are Doomed](https://store.playstation.com/en-us/product/UP2195-CUSA01783_00-WEAREDOOMED00000).
 A compatibility table is in progress and will be available when RPCSX can run commercial games.

--- a/faq.md
+++ b/faq.md
@@ -16,11 +16,7 @@ description: Frequently Asked Questions about RPCSX.
 
 ## Can I run RPCSX on Windows?
 
-**A:** No, currently the project is Linux-only. However, we may support Windows in the future due to popular demand.
-
-### What about the Windows Subsystem for Linux (WSL)?
-
-**A:** Testers have gotten WSL working and we are awaiting instructions for others to use WSL as well. Coming soon. Please be patient.
+**A:** Yes, But only through WSL at this time.
 
 ## What is the current state of the project?
 

--- a/faq.md
+++ b/faq.md
@@ -16,7 +16,7 @@ description: Frequently Asked Questions about RPCSX.
 
 ## Can I run RPCSX on Windows?
 
-**A:** Yes, But only through WSL at this time.
+**A:** Yes, But only through WSL at this time. [learn more](/wiki/installation/#method-2-wsl)
 
 ## What is the current state of the project?
 

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ layout: libdoc/page
 permalink: /
 ---
 
-Welcome to the RPCSX Wiki!
+# Welcome to the RPCSX Wiki
 
 Before you begin, please:
 

--- a/install-guide.md
+++ b/install-guide.md
@@ -10,8 +10,10 @@ description: >-
 - TOC
 {:toc}
 
-## Update!
+## Update
+
 Third party dependencies have been merged into the source tree as submodules! If you previously installed RPCSX when you needed `spirv-cross`, `gslang`, or `xbyak`, you should run:
+
 ```sh
 git pull
 git submodule update --recursive --remote
@@ -23,9 +25,9 @@ We provide two installation methods:
 
 ### Method 1: Linux
 
-#### Install dependencies.
+#### Install dependencies
 
-  - **.deb-based (Ubuntu etc.)** Note: git is only needed for Ubuntu 22.04
+- **.deb-based (Ubuntu etc.)** Note: git is only needed for Ubuntu 22.04
 
 ```sh
 sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev vulkan-validationlayers-dev libsox-dev git libasound2-dev nasm g++-14
@@ -33,7 +35,7 @@ sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev 
 
 go to [Continued Install.](/wiki/installation/#continued-install)
 
-  - **.rpm-based (Fedora etc.)**
+- **.rpm-based (Fedora etc.)**
 
 ```sh
 sudo dnf install cmake libunwind-devel glfw-devel vulkan-devel vulkan-validation-layers-devel gcc-c++ gcc sox-devel alsa-lib-devel nasm
@@ -41,8 +43,8 @@ sudo dnf install cmake libunwind-devel glfw-devel vulkan-devel vulkan-validation
 
 go to [Continued Install.](/wiki/installation/#continued-install)
 
-  - **Arch**
-    - vulkan-devel is a group, and you should install **all**!
+- **Arch**
+  - vulkan-devel is a group, and you should install **all**!
 
 ```sh
 sudo pacman -S --needed libunwind glfw-x11 vulkan-devel sox git cmake alsa-lib nasm
@@ -51,20 +53,93 @@ sudo pacman -S --needed libunwind glfw-x11 vulkan-devel sox git cmake alsa-lib n
 go to [Continued Install.](/wiki/installation/#continued-install)
 
 #### Continued Install
-2. Clone the repo.
 
-```sh
-git clone --recursive https://github.com/RPCSX/rpcsx && cd rpcsx
-git submodule update --init --recursive
-```
+1. Clone the repo.
 
-3. Compile the emulator.
+    ```sh
+    git clone --recursive https://github.com/RPCSX/rpcsx && cd rpcsx
+    git submodule update --init --recursive
+    ```
 
-```sh
-cmake -B build && cmake --build build -j$(nproc)
-```
+2. Compile the emulator.
+
+    ```sh
+    cmake -B build && cmake --build build -j$(nproc)
+    ```
 
 ### Method 2: WSL
-**TODO (Coming Soon)**
+
+**Install WSL**
+Run Windows Powershell as Administrator:
+
+```sh
+wsl --install
+```
+
+Reboot your machine
+
+**Install Ubuntu:**
+Run Windows Powershell
+
+```sh
+wsl --install
+```
+
+Setup user credentials
+
+**Configure Ubuntu and build RPCSX:**
+
+```sh
+sudo add-apt-repository ppa:oibaf/graphics-drivers
+sudo apt upgrade
+```
+
+```sh
+sudo apt install -y build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev libsox-dev git libasound2-dev nasm g++-14
+sudo apt install -y pkgconf libasound2-plugins vainfo mesa-va-drivers
+```
+
+```sh
+echo "pcm.default pulse" > ~/.asoundrc
+```
+
+```sh
+echo "ctl.default pulse" >> ~/.asoundrc
+```
+
+```sh
+git clone --depth 1 https://github.com/KhronosGroup/Vulkan-ExtensionLayer.git
+git clone --depth 1 --recursive https://github.com/RPCSX/rpcsx.git
+```
+
+```sh
+cd Vulkan-ExtensionLayer
+cmake -B build -D UPDATE_DEPS=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j$(nproc)
+sudo cmake --build build --target install -j$(nproc)
+```
+
+```sh
+cd ../rpcsx
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_INIT="-march=native" -DCMAKE_CXX_COMPILER=g++-14
+cmake --build build -j$(nproc)
+sudo cp build/bin/rpcsx /bin
+```
+
+```sh
+echo 'export VK_LAYER_PATH=/usr/local/share/vulkan/explicit_layer.d/:$VK_LAYER_PATH' >> ~/.profile
+```
+
+```sh
+echo 'export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_shader_object' >> ~/.profile
+```
+
+```sh
+sudo init 0
+```
+
+Wait a few minutes to let Linux shutdown
+
 #### ArchWSL
+
 **TODO (under development)**

--- a/install-guide.md
+++ b/install-guide.md
@@ -27,8 +27,8 @@ We provide two installation methods:
 
 #### Install dependencies
 
-- **.deb-based (Ubuntu etc.)**<br>
-Note: git is only needed for Ubuntu 22.04
+- **.deb-based (Ubuntu etc.)**
+  Note: git is only needed for Ubuntu 22.04
 
 ```sh
 sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev vulkan-validationlayers-dev libsox-dev git libasound2-dev nasm g++-14
@@ -44,8 +44,8 @@ sudo dnf install cmake libunwind-devel glfw-devel vulkan-devel vulkan-validation
 
 go to [Continued Install.](/wiki/installation/#continued-install)
 
-- **Arch**<br>
-vulkan-devel is a group, and you should install **all**!
+- **Arch**
+  vulkan-devel is a group, and you should install **all**!
 
 ```sh
 sudo pacman -S --needed libunwind glfw-x11 vulkan-devel sox git cmake alsa-lib nasm
@@ -70,8 +70,8 @@ go to [Continued Install.](/wiki/installation/#continued-install)
 
 ### Method 2: WSL
 
-**Install WSL**<br>
-Run Windows Powershell as Administrator:
+**Install WSL**
+  Run Windows Powershell as Administrator:
 
 ```sh
 wsl --install
@@ -79,8 +79,8 @@ wsl --install
 
 Reboot your machine
 
-**Install Ubuntu:**<br>
-Run Windows Powershell
+**Install Ubuntu:**
+  Run Windows Powershell
 
 ```sh
 wsl --install -d Ubuntu
@@ -88,8 +88,8 @@ wsl --install -d Ubuntu
 
 Setup user credentials
 
-**Configure Ubuntu and build RPCSX:**<br>
-Add the PPA repository that has the packages we need
+**Configure Ubuntu and build RPCSX:**
+  Add the PPA repository that has the packages we need
 
 ```sh
 sudo add-apt-repository ppa:oibaf/graphics-drivers
@@ -163,8 +163,8 @@ Initalize and shutdown the Linux machine
 sudo init 0
 ```
 
-Wait a few minutes to let Linux shutdown.<br>
-This will not turn off your PC only the virtual Ubuntu distro.
+Wait a few minutes to let Linux shutdown.
+  This will not turn off your PC only the virtual Ubuntu distro.
 
 #### ArchWSL
 

--- a/install-guide.md
+++ b/install-guide.md
@@ -27,7 +27,8 @@ We provide two installation methods:
 
 #### Install dependencies
 
-- **.deb-based (Ubuntu etc.)** Note: git is only needed for Ubuntu 22.04
+- **.deb-based (Ubuntu etc.)**<br>
+Note: git is only needed for Ubuntu 22.04
 
 ```sh
 sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev vulkan-validationlayers-dev libsox-dev git libasound2-dev nasm g++-14
@@ -43,8 +44,8 @@ sudo dnf install cmake libunwind-devel glfw-devel vulkan-devel vulkan-validation
 
 go to [Continued Install.](/wiki/installation/#continued-install)
 
-- **Arch**
-  - vulkan-devel is a group, and you should install **all**!
+- **Arch**<br>
+vulkan-devel is a group, and you should install **all**!
 
 ```sh
 sudo pacman -S --needed libunwind glfw-x11 vulkan-devel sox git cmake alsa-lib nasm
@@ -69,7 +70,7 @@ go to [Continued Install.](/wiki/installation/#continued-install)
 
 ### Method 2: WSL
 
-**Install WSL**
+**Install WSL**<br>
 Run Windows Powershell as Administrator:
 
 ```sh
@@ -78,39 +79,55 @@ wsl --install
 
 Reboot your machine
 
-**Install Ubuntu:**
+**Install Ubuntu:**<br>
 Run Windows Powershell
 
 ```sh
-wsl --install
+wsl --install -d Ubuntu
 ```
 
 Setup user credentials
 
-**Configure Ubuntu and build RPCSX:**
+**Configure Ubuntu and build RPCSX:**<br>
+Add the PPA repository that has the packages we need
 
 ```sh
 sudo add-apt-repository ppa:oibaf/graphics-drivers
 sudo apt upgrade
 ```
 
+Install Ubuntu package dependencies
+
 ```sh
-sudo apt install -y build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev libsox-dev git libasound2-dev nasm g++-14
-sudo apt install -y pkgconf libasound2-plugins vainfo mesa-va-drivers
+sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev libsox-dev git libasound2-dev nasm g++-14
 ```
+
+Install WSL specific package dependencies
+
+```sh
+sudo apt install pkgconf libasound2-plugins vainfo mesa-va-drivers
+```
+
+Add pcm.default pulse to the bottom of the .asoundrc file to configure audio
 
 ```sh
 echo "pcm.default pulse" > ~/.asoundrc
 ```
 
+Add ctl.default pulse to the bottom of the .asoundrc file to configure audio
+
 ```sh
 echo "ctl.default pulse" >> ~/.asoundrc
 ```
+
+Clone both Vulkan ExtensionLayer and RPCSX Git repositories
 
 ```sh
 git clone --depth 1 https://github.com/KhronosGroup/Vulkan-ExtensionLayer.git
 git clone --depth 1 --recursive https://github.com/RPCSX/rpcsx.git
 ```
+
+Change directory and compile Vulkan ExtensionLayer
 
 ```sh
 cd Vulkan-ExtensionLayer
@@ -119,6 +136,8 @@ cmake --build build -j$(nproc)
 sudo cmake --build build --target install -j$(nproc)
 ```
 
+Change directory back from Vulkan ExtensionLayer and to RPCSX then compile
+
 ```sh
 cd ../rpcsx
 cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_INIT="-march=native" -DCMAKE_CXX_COMPILER=g++-14
@@ -126,19 +145,26 @@ cmake --build build -j$(nproc)
 sudo cp build/bin/rpcsx /bin
 ```
 
+Tell Ubuntu to set the VK_LAYER_PATH Environment variable
+
 ```sh
 echo 'export VK_LAYER_PATH=/usr/local/share/vulkan/explicit_layer.d/:$VK_LAYER_PATH' >> ~/.profile
 ```
+
+Tell Ubuntu to set the VK_INSTANCE_LAYERS Environment variable
 
 ```sh
 echo 'export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_shader_object' >> ~/.profile
 ```
 
+Initalize and shutdown the Linux machine
+
 ```sh
 sudo init 0
 ```
 
-Wait a few minutes to let Linux shutdown
+Wait a few minutes to let Linux shutdown.<br>
+This will not turn off your PC only the virtual Ubuntu distro.
 
 #### ArchWSL
 

--- a/running.md
+++ b/running.md
@@ -15,21 +15,23 @@ description: >-
 You will need a decrypted dump of the PlayStation 4 console firmware, **OBTAINED LAWFULLY, FROM YOUR OWN PS4 CONSOLE**.
 
 Compatible versions:
+
 - 5.05
 - 9.0
 - 11.0
 
 ## Help
+
 - See the Commands of `rpcsx` (`-h` argument)
 - Join the [Discord](https://discord.com/invite/WEGamDwZnE).
 
-## Booting games:
+## Booting games
 
 ```sh
 ./rpcsx --mount /path/to/firmware/md0/ /  --mount /path/to/game/app0 /app0 /app0/eboot.bin [optional args, without brackets]
 ```
 
-## Booting the firmware:
+## Booting the firmware
 
 ```sh
 ./rpcsx --system --mount /path/to/firmware/md0/ / /mini-syscore.elf
@@ -38,5 +40,6 @@ Compatible versions:
 - Use optional argument `--safemode` for booting in safe mode.
 
 ## Global optional args
+
 - Log a segfault: `--trace`
 - Log to a text file: add `&> log.txt` at the end of the whole command before pressing enter


### PR DESCRIPTION
In these changes, I added a copy-and-paste rough draft of the WSL instructions to the wiki with plans for later to add some more words to better communicate to users what each line of Commands is doing. Such as installing packages and compiling the code using GCC or other decorative words to help make the code blocks a little easier to read.

Speaking of making the code blocks a little easier to read I was using the markdownlint plugin inside visual code to assist in formatting the markdown. Today I re-learned about defining the languages for code blocks and observed that by utilizing them it made the markdown format "prettier" and easier to read/maintain.

These changes today help users on Windows to get up and running with future changes planned to discover ArchWSL install instructions and as mentioned clean up the documentation to put some text between the blocks for ease of readability, communication, and understanding.