### PR TITLE
Update the Wiki with PS5 changes

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,7 +2,7 @@
 permalink: /404.html
 layout: raw
 title: 404 Error - Page Not Found
-description: Sorry, the page you're looking for doesn't exist.
+description: Sorry, the page you are looking for doesn't exist.
 ---
 
 <style type="text/css" media="screen">
@@ -51,6 +51,6 @@ description: Sorry, the page you're looking for doesn't exist.
 
 <div class="container">
 	<h1>404 Error</h1>
-	<p>Sorry, the page you're looking for doesn't exist.</p>
+	<p>Sorry, the page you are looking for doesn't exist.</p>
 	<a href="/wiki/">Back to Home</a>
 </div>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # RPCSX Wiki
 
-## Installation
+This is the repository for hosting and maintaining the RPCSX Wiki.
+All documentation or information to help you have the best possible experience using RPCSX is housed here.
+You can visit the site at anytime from https://rpcsx.github.io/wiki/
+
+## Compiling the Site for Development or Local Hosting Purposes
 
 - Install Ruby:
 
@@ -24,7 +28,7 @@ gem install bundler
 bundle install
 ```
 
-### Development
+### Running the Site for Development or Local Hosting Purposes
 
 - Run Jekyll Server:
 
@@ -34,6 +38,6 @@ Note: Hot reloading is unsupported, refresh the page to see changes.
 bundle exec jekyll serve
 ```
 
-### Before Pushing Changes
+### Before Pushing Changes to the Repository
 
-Run `rubocop` on your local files.
+Run ```rubocop``` on your local files.

--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@
 title: RPCSX Wiki
 email: your-email@example.com
 description: >- # this means to ignore newlines until "baseurl:"
- Documentation for the PlayStation 4 emulator. 
+ Documentation for the PlayStation 4 and PlayStation 5 emulator. 
 baseurl: /wiki/ # the subpath of your site, e.g. /blog
 url: https://rpcsx.github.io # the base hostname & protocol for your site, e.g. http://example.com
 github_username: RPCSX

--- a/about.md
+++ b/about.md
@@ -6,11 +6,12 @@ permalink: /about/
 description: Project links and build info
 ---
 
-This wiki houses documentation and install guides for the PlayStation 4 emulator RPCSX. Development happens on [our GitHub](https://github.com/rpcsx/rpcsx).
+This wiki houses documentation and install guides for the PlayStation 4 and PlayStation 5 emulator RPCSX.
+Development happens on [our GitHub](https://github.com/rpcsx/rpcsx).
 
 You can also find more information on the [official RPCSX website](https://rpcsx.github.io/)
 
-### This wiki was built with Jekyll and LibDoc.
+### This wiki was built with Jekyll and LibDoc
 
 You can find the source code for LibDoc at GitHub:
 [LibDoc](https://github.com/olivier3lanc/Jekyll-LibDoc)

--- a/faq.md
+++ b/faq.md
@@ -8,7 +8,7 @@ description: Frequently Asked Questions about RPCSX.
 
 ## Q: What is RPCSX?
 
-**A:** RPCSX is an experimental emulator for PS4 games (and later, PS5 games). Development is ongoing.
+**A:** RPCSX is an experimental emulator for PS4 and PS5 games. Development is ongoing.
 
 ## Q: Can I play Bloodborne?
 
@@ -20,12 +20,14 @@ description: Frequently Asked Questions about RPCSX.
 
 ## Q: What is the current state of the project?
 
-**A:** The emulator can run test samples and play in-game on [We Are Doomed](https://store.playstation.com/en-us/product/UP2195-CUSA01783_00-WEAREDOOMED00000).
-A compatibility table is in progress and will be available when RPCSX can run commercial games.
+**A:** The emulator can run test samples and play in-game with a handful of titles.
+A compatibility table is in progress.
+Sound works, Controllers work, booting VSH on PS4 and PS5 firmware work, Safemodes for both work.
+Booting games from VSH is a work in progress.
 
 ## Community and Support
 
-Join our [discord server](https://discord.com/invite/WEGamDwZnE) to connect with developers and community members.
+Join our [Discord server](https://discord.com/invite/WEGamDwZnE) to connect with developers and community members.
 
 ## Helping the Project
 

--- a/index.md
+++ b/index.md
@@ -14,6 +14,6 @@ Check our [FAQ](/wiki/faq/) for answers to common questions
 
 Follow the [Installation Guide](/wiki/installation/) to set up the emulator
 
-Learn how to [Run RPCSX](https://rpcsx.github.io/wiki/run/) to play games and apps
+Learn how to [Run RPCSX](/wiki/run/) to play games and apps
 
-Discover more about our project on the [About Page](https://rpcsx.github.io/wiki/about/)
+Discover more about our project on the [About Page](/wiki/about/)

--- a/install-guide.md
+++ b/install-guide.md
@@ -88,83 +88,33 @@ wsl --install -d Ubuntu
 
 Setup user credentials
 
-**Configure Ubuntu and build RPCSX:**
-  Add the PPA repository that has the packages we need
+**Download and install RPCSX:**
+  
+  ```sh
+  wget -O - https://raw.githubusercontent.com/DHrpcs3/rpcsx-setup-wsl/refs/heads/main/rpcsx-setup-wsl.sh | bash
+  ```
 
-```sh
-sudo add-apt-repository ppa:oibaf/graphics-drivers
-sudo apt upgrade
-```
+  - This script will shutdown your Ubuntu distro when complete, This will not turn off your PC only the virtual environment
+  
+  After the script has completed succesfully relaunch ubuntu through Windows Powershell
 
-Install Ubuntu package dependencies
+  ```sh
+  wsl
+  ```
 
-```sh
-sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev libsox-dev git libasound2-dev nasm g++-14
-```
+  Validate RPCSX installed
 
-Install WSL specific package dependencies
+  ```sh
+  rpcsx --version
+  ```
 
-```sh
-sudo apt install pkgconf libasound2-plugins vainfo mesa-va-drivers
-```
+  You are now free to continue onto the [Running RPCSX Guide](/wiki/run/)
 
-Add pcm.default pulse to the bottom of the .asoundrc file to configure audio
+  To update RPCSX for WSL in the future you may use this command
 
-```sh
-echo "pcm.default pulse" > ~/.asoundrc
-```
-
-Add ctl.default pulse to the bottom of the .asoundrc file to configure audio
-
-```sh
-echo "ctl.default pulse" >> ~/.asoundrc
-```
-
-Clone both Vulkan ExtensionLayer and RPCSX Git repositories
-
-```sh
-git clone --depth 1 https://github.com/KhronosGroup/Vulkan-ExtensionLayer.git
-git clone --depth 1 --recursive https://github.com/RPCSX/rpcsx.git
-```
-
-Change directory and compile Vulkan ExtensionLayer
-
-```sh
-cd Vulkan-ExtensionLayer
-cmake -B build -D UPDATE_DEPS=ON -DCMAKE_BUILD_TYPE=Release
-cmake --build build -j$(nproc)
-sudo cmake --build build --target install -j$(nproc)
-```
-
-Change directory back from Vulkan ExtensionLayer and to RPCSX then compile
-
-```sh
-cd ../rpcsx
-cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_INIT="-march=native" -DCMAKE_CXX_COMPILER=g++-14
-cmake --build build -j$(nproc)
-sudo cp build/bin/rpcsx /bin
-```
-
-Tell Ubuntu to set the VK_LAYER_PATH Environment variable
-
-```sh
-echo 'export VK_LAYER_PATH=/usr/local/share/vulkan/explicit_layer.d/:$VK_LAYER_PATH' >> ~/.profile
-```
-
-Tell Ubuntu to set the VK_INSTANCE_LAYERS Environment variable
-
-```sh
-echo 'export VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_shader_object' >> ~/.profile
-```
-
-Initalize and shutdown the Linux machine
-
-```sh
-sudo init 0
-```
-
-Wait a few minutes to let Linux shutdown.
-  This will not turn off your PC only the virtual Ubuntu distro.
+  ```sh
+  rpcsx-update
+  ```
 
 #### ArchWSL
 

--- a/running.md
+++ b/running.md
@@ -12,34 +12,36 @@ description: >-
 
 ## Prerequisites
 
-You will need a decrypted dump of the PlayStation 4 console firmware, **OBTAINED LAWFULLY, FROM YOUR OWN PS4 CONSOLE**.
-
-Compatible versions:
-
-- 5.05
-- 9.0
-- 11.0
+You will need a decrypted dump of the PlayStation 4 or PlayStation 5 console firmware, **OBTAINED LAWFULLY, FROM YOUR OWN PS4 OR PS5 CONSOLE**.
 
 ## Help
 
 - See the Commands of `rpcsx` (`-h` argument)
-- Join the [Discord](https://discord.com/invite/WEGamDwZnE).
+- Join our [Discord](https://discord.com/invite/WEGamDwZnE) for support and discussion.
 
 ## Booting games
 
 ```sh
-./rpcsx --mount /path/to/firmware/md0/ /  --mount /path/to/game/app0 /app0 /app0/eboot.bin [optional args, without brackets]
+rpcsx --fw <path to fw> games/CUSA##### [optional args, without brackets]
 ```
 
 ## Booting the firmware
 
 ```sh
-./rpcsx --system --mount /path/to/firmware/md0/ / /mini-syscore.elf
+rpcsx --fw <path to fw>
 ```
 
-- Use optional argument `--safemode` for booting in safe mode.
+- Use the optional argument `--safemode` for booting in safe mode.
 
 ## Global optional args
 
 - Log a segfault: `--trace`
 - Log to a text file: add `&> log.txt` at the end of the whole command before pressing enter
+
+## Booting Samples
+
+At the time of writing, booting samples requires advanced mounting commands for firmware and path to sample. Simplified commands will not work.
+
+```sh
+./rpcsx --mount  "<path to fw>/system" "/system" --mount "<path to 'game' root>" /app0 /app0/some-test-sample.elf [<args for test elf>...]
+```


### PR DESCRIPTION
DH made a new WSL script today for ease of installation to help Windows people get started.
So I incorporated that script into the install guide and decided to run through every file and clean up what I could see.
PlayStation 5 support was added to RPCSX and there is a lot more working than just 2 titles at this time.
Many games are seeing title screens and commands were overdue on a simplification for booting content.